### PR TITLE
Fix `LOCAL_GCS` env variable name mismatch typo.

### DIFF
--- a/src/shared/url_types.ts
+++ b/src/shared/url_types.ts
@@ -27,7 +27,7 @@ export const allCloudBuckets = valueLiteral<CloudBucket>()({
 });
 
 export function useLocalDisk() {
-  return process.env.GCS_LOCAL_DISK === "1";
+  return process.env.LOCAL_GCS === "1";
 }
 
 export function bucketURL(bucket: string, path: string, useCDN = true) {

--- a/src/shared/url_types.ts
+++ b/src/shared/url_types.ts
@@ -44,7 +44,7 @@ export function bucketURL(bucket: string, path: string, useCDN = true) {
 }
 
 export function localPath(bucket: CloudBucketKey, path: string) {
-  return `./public/buckets/${bucketURL(bucket, path)}`;
+  return `./public${bucketURL(bucket, path)}`;
 }
 
 type ValidCloudBucketKey = keyof typeof allCloudBuckets;


### PR DESCRIPTION
copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why

Typo from a last minute change, made it so that player meshes wouldn't load properly.

### how

copilot:walkthrough
