### PR TITLE
Added CI for docs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,7 +16,9 @@ jobs:
           node-version: 18
           cache: yarn
 
-      - name: Install dependencies
+      - name: Install project dependencies
+        run: yarn install --frozen-lockfile
+      - name: Install docs dependencies
         working-directory: ./docs
         run: yarn install --frozen-lockfile
       - name: Build website

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: 18
           cache: yarn
 
+      - run: cd docs
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Build website

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,10 +16,11 @@ jobs:
           node-version: 18
           cache: yarn
 
-      - run: cd docs
       - name: Install dependencies
+        working-directory: ./docs
         run: yarn install --frozen-lockfile
       - name: Build website
+        working-directory: ./docs
         run: yarn build
 
       - name: Deploy to GitHub Pages
@@ -27,7 +28,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Contents of "build" are published to the `gh-pages` branch.
-          publish_dir: ./build
+          publish_dir: ./docs/build
           # Assign commit authorship to the official GH-Actions bot.
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy docs to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Build website
+        run: yarn build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Contents of "build" are published to the `gh-pages` branch.
+          publish_dir: ./build
+          # Assign commit authorship to the official GH-Actions bot.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/docs-test-deploy.yml
+++ b/.github/workflows/docs-test-deploy.yml
@@ -1,0 +1,22 @@
+name: Test docs deployment
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-deploy:
+    name: Test docs deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Test build website
+        run: yarn build

--- a/.github/workflows/docs-test-deploy.yml
+++ b/.github/workflows/docs-test-deploy.yml
@@ -16,8 +16,9 @@ jobs:
           node-version: 18
           cache: yarn
 
-      - run: cd docs
       - name: Install dependencies
+        working-directory: ./docs
         run: yarn install --frozen-lockfile
       - name: Test build website
+        working-directory: ./docs
         run: yarn build

--- a/.github/workflows/docs-test-deploy.yml
+++ b/.github/workflows/docs-test-deploy.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: 18
           cache: yarn
 
+      - run: cd docs
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Test build website

--- a/.github/workflows/docs-test-deploy.yml
+++ b/.github/workflows/docs-test-deploy.yml
@@ -16,7 +16,9 @@ jobs:
           node-version: 18
           cache: yarn
 
-      - name: Install dependencies
+      - name: Install project dependencies
+        run: yarn install --frozen-lockfile
+      - name: Install docs dependencies
         working-directory: ./docs
         run: yarn install --frozen-lockfile
       - name: Test build website


### PR DESCRIPTION
copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why
- `On pull request` the docs are built and their build status is reported.
- `On push to main` the docs are built and deployed.
- Follows https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions.
- Note: May require a GitHub secret (not sure because PRs currently don't require approval to be merged)

### how

copilot:walkthrough
