### PR TITLE
Explicity build docs + update node version

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -13,9 +13,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
-
       - name: Install project dependencies
         run: yarn install --frozen-lockfile
       - name: Install docs dependencies
@@ -23,8 +22,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Build website
         working-directory: ./docs
-        run: yarn build
-
+        run: yarn run -- docusaurus build
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/docs-test-deploy.yml
+++ b/.github/workflows/docs-test-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install project dependencies
@@ -23,4 +23,4 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Test build website
         working-directory: ./docs
-        run: yarn build
+        run: yarn run -- docusaurus build


### PR DESCRIPTION
copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why
- The deployment workflow is not creating (and therefore not serving) the hashed imaged assets. This is an attempt to fix that. The assets are produced when built locally, so there's something different between the GitHub actions workflow environment the dev environment. 

### how

copilot:walkthrough
