### PR TITLE
Disable gcloud auth on PR gate tests.

### DIFF
--- a/.github/actions/bazel/action.yml
+++ b/.github/actions/bazel/action.yml
@@ -13,9 +13,11 @@ runs:
   using: "composite"
   steps:
     # Store our Google Cloud credentials into a home directory .bazelrc.
-    # Requires that we have previously authenticated with Google Cloud.
+    # Requires that we have previously authenticated with Google Cloud,
+    # so only run the command if GOOGLE_GHA_CREDS_PATH is set, otherwise we
+    # don't use remote caching.
     - name: "Configure local .bazelrc with auth credentials."
-      run: "echo \"build --config=with-remote-cache --google_credentials=\\\"${GOOGLE_GHA_CREDS_PATH}\\\"\" >> ${HOME}/.bazelrc"
+      run: "[[ -n $GOOGLE_GHA_CREDS_PATH ]] && echo \"build --config=with-remote-cache --google_credentials=\\\"${GOOGLE_GHA_CREDS_PATH}\\\"\" >> ${HOME}/.bazelrc"
       shell: bash
     # We cache the output_user_root since it contains *all* of the downloaded
     # files. We can `bazel build` with the `--nofetch` flag after this.

--- a/.github/actions/bazel/action.yml
+++ b/.github/actions/bazel/action.yml
@@ -17,7 +17,7 @@ runs:
     # so only run the command if GOOGLE_GHA_CREDS_PATH is set, otherwise we
     # don't use remote caching.
     - name: "Configure local .bazelrc with auth credentials."
-      run: "[[ -n $GOOGLE_GHA_CREDS_PATH ]] && echo \"build --config=with-remote-cache --google_credentials=\\\"${GOOGLE_GHA_CREDS_PATH}\\\"\" >> ${HOME}/.bazelrc"
+      run: "[[ -z $GOOGLE_GHA_CREDS_PATH ]] || echo \"build --config=with-remote-cache --google_credentials=\\\"${GOOGLE_GHA_CREDS_PATH}\\\"\" >> ${HOME}/.bazelrc"
       shell: bash
     # We cache the output_user_root since it contains *all* of the downloaded
     # files. We can `bazel build` with the `--nofetch` flag after this.

--- a/.github/workflows/bazel-ci.yml
+++ b/.github/workflows/bazel-ci.yml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      # gcloud auth needed to access bazel remote cache on GCS
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install

--- a/.github/workflows/galois-ci.yml
+++ b/.github/workflows/galois-ci.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install
@@ -43,8 +41,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install
@@ -64,8 +60,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install

--- a/.github/workflows/merge-ci.yml
+++ b/.github/workflows/merge-ci.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install

--- a/.github/workflows/redis-ci.yml
+++ b/.github/workflows/redis-ci.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install

--- a/.github/workflows/ts-ci.yml
+++ b/.github/workflows/ts-ci.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install

--- a/.github/workflows/ts-eslint-ci.yml
+++ b/.github/workflows/ts-eslint-ci.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: gcloud auth
-        uses: ./.github/actions/gcloud-auth
       - name: git lfs pull
         uses: ./.github/actions/cached-lfs-pull
       - name: yarn install


### PR DESCRIPTION
External PRs from forked repos don't have access
to our secrets, for security reasons, so they can't get gcloud access.

copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why
<!-- author to complete -->

### how

copilot:walkthrough
