### PR TITLE
Admin view to edit ECS data

### DIFF
--- a/ecs/defs.py
+++ b/ecs/defs.py
@@ -3306,6 +3306,7 @@ def define_events(g: Generator):
         "AdminECSDeleteComponent",
         OrderedDict(
             id=s.BiomesId,
+            userId=s.BiomesId,
             field=s.String
         )
     )
@@ -3314,6 +3315,7 @@ def define_events(g: Generator):
         "AdminECSAddComponent",
         OrderedDict(
             id=s.BiomesId,
+            userId=s.BiomesId,
             field=s.String
         )
     )
@@ -3322,6 +3324,7 @@ def define_events(g: Generator):
         "AdminECSUpdateComponent",
         OrderedDict(
             id=s.BiomesId,
+            userId=s.BiomesId,
             path=s.Strings,
             value=s.String
         )

--- a/ecs/defs.py
+++ b/ecs/defs.py
@@ -3319,6 +3319,15 @@ def define_events(g: Generator):
     )
 
     g.add_event(
+        "AdminECSUpdateComponent",
+        OrderedDict(
+            id=s.BiomesId,
+            path=s.Strings,
+            value=s.String
+        )
+    )
+
+    g.add_event(
         "CreateTeam",
         OrderedDict(
             id=s.BiomesId,

--- a/ecs/defs.py
+++ b/ecs/defs.py
@@ -3303,7 +3303,7 @@ def define_events(g: Generator):
     )
 
     g.add_event(
-        "AdminECSDeleteField",
+        "AdminECSDeleteComponent",
         OrderedDict(
             id=s.BiomesId,
             field=s.String
@@ -3311,7 +3311,7 @@ def define_events(g: Generator):
     )
 
     g.add_event(
-        "AdminECSAddField",
+        "AdminECSAddComponent",
         OrderedDict(
             id=s.BiomesId,
             field=s.String

--- a/ecs/defs.py
+++ b/ecs/defs.py
@@ -3303,6 +3303,22 @@ def define_events(g: Generator):
     )
 
     g.add_event(
+        "AdminECSDeleteField",
+        OrderedDict(
+            id=s.BiomesId,
+            field=s.String
+        )
+    )
+
+    g.add_event(
+        "AdminECSAddField",
+        OrderedDict(
+            id=s.BiomesId,
+            field=s.String
+        )
+    )
+
+    g.add_event(
         "CreateTeam",
         OrderedDict(
             id=s.BiomesId,

--- a/src/client/styles/admin.ecs.css
+++ b/src/client/styles/admin.ecs.css
@@ -1,0 +1,3 @@
+.react-json-view > .validation-failure {
+  display: none !important;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import "@/client/styles/admin.css";
+import "@/client/styles/admin.ecs.css"
 import "@/client/styles/biomes.css";
 import "@/client/styles/challenges.css";
 import "@/client/styles/collections.css";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,5 @@
 import "@/client/styles/admin.css";
-import "@/client/styles/admin.ecs.css"
+import "@/client/styles/admin.ecs.css";
 import "@/client/styles/biomes.css";
 import "@/client/styles/challenges.css";
 import "@/client/styles/collections.css";

--- a/src/pages/admin/ecs/[id].tsx
+++ b/src/pages/admin/ecs/[id].tsx
@@ -194,6 +194,11 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
     const currentValue = field.existing_value;
     const newValue = field.new_value;
 
+    if (field.name === "id") {
+      setError("Can't edit id.");
+      return;
+    }
+
     if (
       currentValue === undefined ||
       currentValue === null ||

--- a/src/pages/admin/ecs/[id].tsx
+++ b/src/pages/admin/ecs/[id].tsx
@@ -149,6 +149,7 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
     void refetchEntity().then((entity) => {
       if (entity) {
         setEntity(entity);
+        setError("");
       } else {
         setError("Failed to fetch after update.");
       }
@@ -173,7 +174,6 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
       return;
     }
 
-    setError("");
     const successful = await doECSEdit({
       id: entity.id,
       edit: {
@@ -216,7 +216,6 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
       return;
     }
 
-    setError("");
     const serialized = (newValue as number | string | boolean).toString();
     const successful = await doECSEdit({
       id: entity.id,
@@ -238,7 +237,6 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
       return;
     }
 
-    setError("");
     const successful = await doECSEdit({
       id: entity.id,
       edit: {

--- a/src/pages/admin/ecs/[id].tsx
+++ b/src/pages/admin/ecs/[id].tsx
@@ -5,7 +5,7 @@ import { DialogBoxContents } from "@/client/components/system/DialogBox";
 import { DialogButton } from "@/client/components/system/DialogButton";
 import { DialogTextInput } from "@/client/components/system/DialogTextInput";
 import { MaybeError } from "@/client/components/system/MaybeError";
-import {
+import type {
   AdminECSEditRequest,
   AdminECSEditResponse,
 } from "@/pages/api/admin/ecs/edit";
@@ -14,9 +14,9 @@ import { usernameOrIdToUser } from "@/server/web/util/admin";
 import { biomesGetServerSideProps } from "@/server/web/util/ssp_middleware";
 import type { Entity } from "@/shared/ecs/gen/entities";
 import { Npc, Player } from "@/shared/ecs/gen/entities";
+import type { LegacyIdOrBiomesId } from "@/shared/ids";
 import {
   INVALID_BIOMES_ID,
-  LegacyIdOrBiomesId,
   legacyIdOrBiomesId,
   zUsernameOrAnyId,
 } from "@/shared/ids";
@@ -24,7 +24,7 @@ import { jsonPost, zjsonPost } from "@/shared/util/fetch_helpers";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useState } from "react";
-import { InteractionProps } from "react-json-view";
+import type { InteractionProps } from "react-json-view";
 import { z } from "zod";
 
 export const getServerSideProps = biomesGetServerSideProps(
@@ -190,7 +190,7 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
     if (!field.name || field.namespace.find((x) => x === null) !== undefined) {
       return;
     }
-    const path = [...(field.namespace as string[]), field.name as string];
+    const path = [...(field.namespace as string[]), field.name];
     const currentValue = field.existing_value;
     const newValue = field.new_value;
 
@@ -268,13 +268,13 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
         </div>
         <AdminReactJSON
           onEdit={(field) => {
-            onEdit(field);
+            void onEdit(field);
             return false;
           }}
           src={entity}
           collapsed={1}
           onDelete={(field) => {
-            onDelete(field);
+            void onDelete(field);
             return false;
           }}
           sortKeys

--- a/src/pages/admin/ecs/[id].tsx
+++ b/src/pages/admin/ecs/[id].tsx
@@ -14,6 +14,7 @@ import {
 } from "@/shared/ids";
 import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
+import { InteractionProps, OnSelectProps } from "react-json-view";
 import { z } from "zod";
 
 export const getServerSideProps = biomesGetServerSideProps(
@@ -101,10 +102,34 @@ const AdminEntityPage: React.FunctionComponent<
   );
 };
 
+const CANCEL = false;
+
 const ECSEditor: React.FC<{ entity: Entity }> = ({ entity }) => {
+  const onDelete = (field: InteractionProps) => {
+    console.log(onDelete);
+
+    return CANCEL;
+  };
+
+  const onSelection = (select: OnSelectProps) => {
+    
+    return CANCEL;
+  };
+
+  const onEdit = (field: InteractionProps) => {
+    return CANCEL;
+  };
+
   return (
     <>
-      <AdminReactJSON src={entity} collapsed={1} sortKeys />
+      <AdminReactJSON
+        onEdit={onEdit}
+        src={entity}
+        collapsed={1}
+        onSelect={onSelection}
+        onDelete={onDelete}
+        sortKeys
+      />
     </>
   );
 };

--- a/src/pages/admin/ecs/[id].tsx
+++ b/src/pages/admin/ecs/[id].tsx
@@ -210,10 +210,8 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
       setError("Can't set to null, undefined, or object.");
       return;
     }
-    if (typeof newValue !== typeof currentValue) {
-      setError("Type of new value must match type of old value.");
-      return;
-    }
+
+    setError("");
     const serialized = (newValue as number | string | boolean).toString();
     const successful = await doECSEdit({
       id: entity.id,
@@ -235,6 +233,7 @@ const ECSEditor: React.FC<{ entity: Entity }> = ({ entity: initialEntity }) => {
       return;
     }
 
+    setError("");
     const successful = await doECSEdit({
       id: entity.id,
       edit: {

--- a/src/pages/admin/ecs/[id].tsx
+++ b/src/pages/admin/ecs/[id].tsx
@@ -77,23 +77,35 @@ const AdminEntityPage: React.FunctionComponent<
   }
 
   const { entity, version } = entityOrError.result;
-  return (
-    <AdminPage>
-      {entity ? (
-        <>
-          <h2>ECS {entity.id}</h2>
-          {version !== undefined && <p>Version: {version}</p>}
-          <EntityTypeDetails entity={entity}></EntityTypeDetails>
-          <br></br>
-          <AdminReactJSON src={entity} collapsed={1} />
-        </>
-      ) : (
+  if (!entity) {
+    return (
+      <AdminPage>
         <>
           <div className="error">Entity not found!</div>
           {version !== undefined && <p>Version: {version}</p>}
         </>
-      )}
+      </AdminPage>
+    );
+  }
+
+  return (
+    <AdminPage>
+      <>
+        <h2>ECS {entity.id}</h2>
+        {version !== undefined && <p>Version: {version}</p>}
+        <EntityTypeDetails entity={entity}></EntityTypeDetails>
+        <br></br>
+        <ECSEditor entity={entity} />
+      </>
     </AdminPage>
+  );
+};
+
+const ECSEditor: React.FC<{ entity: Entity }> = ({ entity }) => {
+  return (
+    <>
+      <AdminReactJSON src={entity} collapsed={1} sortKeys />
+    </>
   );
 };
 

--- a/src/pages/admin/ecs/[id].tsx
+++ b/src/pages/admin/ecs/[id].tsx
@@ -85,7 +85,7 @@ const AdminEntityPage: React.FunctionComponent<
           {version !== undefined && <p>Version: {version}</p>}
           <EntityTypeDetails entity={entity}></EntityTypeDetails>
           <br></br>
-          <AdminReactJSON src={entity} collapsed />
+          <AdminReactJSON src={entity} collapsed={1} />
         </>
       ) : (
         <>

--- a/src/pages/admin/user/[id].tsx
+++ b/src/pages/admin/user/[id].tsx
@@ -753,6 +753,7 @@ export const AdminUserPage: React.FunctionComponent<
           </li>
           <li>
             <h2> Game data </h2>
+            <Link href={`/admin/ecs/${user.id}`}>Edit game data (ECS)</Link>
             <AdminReactJSON src={entity ?? {}} collapsed />
           </li>
         </ul>

--- a/src/pages/api/admin/ecs/edit.ts
+++ b/src/pages/api/admin/ecs/edit.ts
@@ -1,6 +1,9 @@
 import { GameEvent } from "@/server/shared/api/game_event";
 import { biomesApiHandler } from "@/server/web/util/api_middleware";
-import { AdminECSAddFieldEvent, AdminECSDeleteFieldEvent } from "@/shared/ecs/gen/events";
+import {
+  AdminECSAddComponentEvent,
+  AdminECSDeleteComponentEvent,
+} from "@/shared/ecs/gen/events";
 import { zBiomesId } from "@/shared/ids";
 import { z } from "zod";
 
@@ -42,7 +45,7 @@ export default biomesApiHandler(
         await context.logicApi.publish(
           new GameEvent(
             userId,
-            new AdminECSDeleteFieldEvent({ id, field: edit.field })
+            new AdminECSDeleteComponentEvent({ id, field: edit.field })
           )
         );
         return { success: true };
@@ -50,7 +53,7 @@ export default biomesApiHandler(
         await context.logicApi.publish(
           new GameEvent(
             userId,
-            new AdminECSAddFieldEvent({ id, field: edit.field })
+            new AdminECSAddComponentEvent({ id, field: edit.field })
           )
         );
         return { success: true };

--- a/src/pages/api/admin/ecs/edit.ts
+++ b/src/pages/api/admin/ecs/edit.ts
@@ -1,0 +1,58 @@
+import { GameEvent } from "@/server/shared/api/game_event";
+import { biomesApiHandler } from "@/server/web/util/api_middleware";
+import { AdminECSDeleteFieldEvent } from "@/shared/ecs/gen/events";
+import { zBiomesId } from "@/shared/ids";
+import { z } from "zod";
+
+export const zAdminECSEditRequest = z.object({
+  id: zBiomesId,
+  edit: z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("add"),
+      field: z.string(),
+    }),
+    z.object({
+      kind: z.literal("delete"),
+      field: z.string(),
+    }),
+    z.object({
+      kind: z.literal("edit"),
+      field: z.string().array(),
+      value: z.any(),
+    }),
+  ]),
+});
+export type AdminECSEditRequest = z.infer<typeof zAdminECSEditRequest>;
+
+export const zAdminECSEditResponse = z.object({
+  success: z.boolean(),
+});
+export type AdminECSEditResponse = z.infer<typeof zAdminECSEditResponse>;
+
+export default biomesApiHandler(
+  {
+    auth: "admin",
+    body: zAdminECSEditRequest,
+    response: zAdminECSEditResponse,
+  },
+  async ({ auth: { userId }, body: { id, edit }, context }) => {
+    try {
+      if (edit.kind === "delete") {
+        // Delete the field.
+        await context.logicApi.publish(
+          new GameEvent(
+            userId,
+            new AdminECSDeleteFieldEvent({ id, field: edit.field })
+          )
+        );
+        return { success: true };
+      } else if (edit.kind === "add") {
+        // TODO
+      } else if (edit.kind === "edit") {
+        // TODO
+      }
+    } catch (_e) {}
+
+    return { success: false };
+  }
+);

--- a/src/pages/api/admin/ecs/edit.ts
+++ b/src/pages/api/admin/ecs/edit.ts
@@ -45,14 +45,14 @@ export default biomesApiHandler(
         await context.logicApi.publish(
           new GameEvent(
             userId,
-            new AdminECSDeleteComponentEvent({ id, field: edit.field })
+            new AdminECSDeleteComponentEvent({ id, userId, field: edit.field })
           )
         );
       } else if (edit.kind === "add") {
         await context.logicApi.publish(
           new GameEvent(
             userId,
-            new AdminECSAddComponentEvent({ id, field: edit.field })
+            new AdminECSAddComponentEvent({ id, userId, field: edit.field })
           )
         );
       } else if (edit.kind === "update") {
@@ -61,6 +61,7 @@ export default biomesApiHandler(
             userId,
             new AdminECSUpdateComponentEvent({
               id,
+              userId,
               path: edit.path,
               value: edit.value,
             })

--- a/src/pages/api/admin/ecs/edit.ts
+++ b/src/pages/api/admin/ecs/edit.ts
@@ -1,6 +1,6 @@
 import { GameEvent } from "@/server/shared/api/game_event";
 import { biomesApiHandler } from "@/server/web/util/api_middleware";
-import { AdminECSDeleteFieldEvent } from "@/shared/ecs/gen/events";
+import { AdminECSAddFieldEvent, AdminECSDeleteFieldEvent } from "@/shared/ecs/gen/events";
 import { zBiomesId } from "@/shared/ids";
 import { z } from "zod";
 
@@ -47,7 +47,13 @@ export default biomesApiHandler(
         );
         return { success: true };
       } else if (edit.kind === "add") {
-        // TODO
+        await context.logicApi.publish(
+          new GameEvent(
+            userId,
+            new AdminECSAddFieldEvent({ id, field: edit.field })
+          )
+        );
+        return { success: true };
       } else if (edit.kind === "edit") {
         // TODO
       }

--- a/src/pages/api/admin/ecs/get.ts
+++ b/src/pages/api/admin/ecs/get.ts
@@ -1,12 +1,19 @@
 import { biomesApiHandler } from "@/server/web/util/api_middleware";
 import { WrappedEntity, zEntity } from "@/shared/ecs/zod";
 import { zBiomesId } from "@/shared/ids";
+import { z } from "zod";
+
+export const zAdminEntityGetRequest = zBiomesId.array();
+export type AdminEntityGetRequest = z.infer<typeof zAdminEntityGetRequest>;
+
+export const zAdminEntityGetResponse = z.array(zEntity.optional());
+export type AdminEntityGetResponse = z.infer<typeof zAdminEntityGetResponse>;
 
 export default biomesApiHandler(
   {
     auth: "admin",
-    body: zBiomesId.array(),
-    response: zEntity.optional().array(),
+    body: zAdminEntityGetRequest,
+    response: zAdminEntityGetResponse,
     zrpc: true,
   },
   async ({ context: { worldApi }, body: ids }) =>

--- a/src/server/logic/events/all.ts
+++ b/src/server/logic/events/all.ts
@@ -2,6 +2,7 @@ import type { AnyEventHandler } from "@/server/logic/events/core";
 import {
   adminDeleteEventHandler,
   adminDestroyPlantEventHandler,
+  adminECSDeleteFieldEventHandler,
   adminEditPresetEventHandler,
   adminGiveItemEventHandler,
   adminIceEventHandler,
@@ -144,6 +145,7 @@ export function eventHandlerMapFor(serverMods: ServerMods) {
     adminEditPresetEventHandler,
     adminDestroyPlantEventHandler,
     adminUpdateInspectionTweaksHandler,
+    adminECSDeleteFieldEventHandler,
 
     // Challenge events
     acceptChallengeEventHandler,

--- a/src/server/logic/events/all.ts
+++ b/src/server/logic/events/all.ts
@@ -2,8 +2,8 @@ import type { AnyEventHandler } from "@/server/logic/events/core";
 import {
   adminDeleteEventHandler,
   adminDestroyPlantEventHandler,
-  adminECSAddFieldEventHandler,
-  adminECSDeleteFieldEventHandler,
+  adminECSAddComponentEventHandler,
+  adminECSDeleteComponentEventHandler,
   adminEditPresetEventHandler,
   adminGiveItemEventHandler,
   adminIceEventHandler,
@@ -146,8 +146,8 @@ export function eventHandlerMapFor(serverMods: ServerMods) {
     adminEditPresetEventHandler,
     adminDestroyPlantEventHandler,
     adminUpdateInspectionTweaksHandler,
-    adminECSDeleteFieldEventHandler,
-    adminECSAddFieldEventHandler,
+    adminECSDeleteComponentEventHandler,
+    adminECSAddComponentEventHandler,
 
     // Challenge events
     acceptChallengeEventHandler,

--- a/src/server/logic/events/all.ts
+++ b/src/server/logic/events/all.ts
@@ -4,6 +4,7 @@ import {
   adminDestroyPlantEventHandler,
   adminECSAddComponentEventHandler,
   adminECSDeleteComponentEventHandler,
+  adminECSUpdateComponentEventHandler,
   adminEditPresetEventHandler,
   adminGiveItemEventHandler,
   adminIceEventHandler,
@@ -111,7 +112,7 @@ import { updateProjectedRestorationEventHandler } from "@/server/logic/events/ha
 import { allRobotHandlers } from "@/server/logic/events/handlers/robot";
 import { allTeamEventHandlers } from "@/server/logic/events/handlers/teams";
 import { allTradeEventHandlers } from "@/server/logic/events/handlers/trade";
-import type { EventSet } from "@/shared/ecs/gen/events";
+import { type EventSet } from "@/shared/ecs/gen/events";
 import type { RegistryLoader } from "@/shared/registry";
 import { ok } from "assert";
 export type EventHandlerMap = Map<keyof EventSet, AnyEventHandler>;
@@ -148,6 +149,7 @@ export function eventHandlerMapFor(serverMods: ServerMods) {
     adminUpdateInspectionTweaksHandler,
     adminECSDeleteComponentEventHandler,
     adminECSAddComponentEventHandler,
+    adminECSUpdateComponentEventHandler,
 
     // Challenge events
     acceptChallengeEventHandler,

--- a/src/server/logic/events/all.ts
+++ b/src/server/logic/events/all.ts
@@ -2,6 +2,7 @@ import type { AnyEventHandler } from "@/server/logic/events/core";
 import {
   adminDeleteEventHandler,
   adminDestroyPlantEventHandler,
+  adminECSAddFieldEventHandler,
   adminECSDeleteFieldEventHandler,
   adminEditPresetEventHandler,
   adminGiveItemEventHandler,
@@ -146,6 +147,7 @@ export function eventHandlerMapFor(serverMods: ServerMods) {
     adminDestroyPlantEventHandler,
     adminUpdateInspectionTweaksHandler,
     adminECSDeleteFieldEventHandler,
+    adminECSAddFieldEventHandler,
 
     // Challenge events
     acceptChallengeEventHandler,

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -275,8 +275,8 @@ function callMethod(entity: Delta, method: string, ...args: any[]): any {
 // Attempts to delete a field from an entity.
 //
 // Throws if the component does not exist.
-export const adminECSDeleteFieldEventHandler = makeEventHandler(
-  "adminECSDeleteFieldEvent",
+export const adminECSDeleteComponentEventHandler = makeEventHandler(
+  "adminECSDeleteComponentEvent",
   {
     mergeKey: (event) => event.id,
     involves: (event) => ({
@@ -299,8 +299,8 @@ export const adminECSDeleteFieldEventHandler = makeEventHandler(
 // Attempts to add the default value of a component to an entity.
 //
 // Throws if the component does not exist.
-export const adminECSAddFieldEventHandler = makeEventHandler(
-  "adminECSAddFieldEvent",
+export const adminECSAddComponentEventHandler = makeEventHandler(
+  "adminECSAddComponentEvent",
   {
     mergeKey: (event) => event.id,
     involves: (event) => ({

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -272,7 +272,7 @@ function callMethod(entity: Delta, method: string, ...args: any[]): any {
   return (entity[method as EntityField] as any)(...args);
 }
 
-// Attempts to delete a field from an entity.
+// Delete a component from an entity.
 //
 // Throws if the component does not exist.
 export const adminECSDeleteComponentEventHandler = makeEventHandler(
@@ -296,7 +296,7 @@ export const adminECSDeleteComponentEventHandler = makeEventHandler(
   }
 );
 
-// Attempts to add the default value of a component to an entity.
+// Add the default value of a component to an entity.
 //
 // Throws if the component does not exist.
 export const adminECSAddComponentEventHandler = makeEventHandler(
@@ -304,7 +304,7 @@ export const adminECSAddComponentEventHandler = makeEventHandler(
   {
     mergeKey: (event) => event.id,
     involves: (event) => ({
-      entity: q.id(event.id),
+      entity: q.includeIced(event.id),
     }),
     apply({ entity }, { field }, _context) {
       const componentName = snakeCaseToUpperCamalCase(field);
@@ -317,6 +317,26 @@ export const adminECSAddComponentEventHandler = makeEventHandler(
       // @ts-ignore (ignore cannot index Component with componentName error)
       const newComponent = Component[componentName].create();
       callMethod(entity, setComponentMethod, newComponent);
+    },
+  }
+);
+
+// Edits a field within a component.
+//
+// Throws if the component does not exist or the edit path is invalid.
+export const adminECSUpdateComponentEventHandler = makeEventHandler(
+  "adminECSUpdateComponentEvent",
+  {
+    mergeKey: (event) => event.id,
+    involves: (event) => ({
+      entity: q.includeIced(event.id),
+    }),
+    apply({ entity }, { path, value }, _context) {
+      if (path.length === 0) {
+        throw new Error("invalid edit path");
+      }
+
+      // TODO
     },
   }
 );

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -13,7 +13,6 @@ import { getBiscuit } from "@/shared/bikkie/active";
 import { secondsSinceEpoch } from "@/shared/ecs/config";
 import * as Component from "@/shared/ecs/gen/components";
 import { RecipeBook } from "@/shared/ecs/gen/components";
-import type { Delta } from "@/shared/ecs/gen/delta";
 import { anItem } from "@/shared/game/item";
 import { removeFromSet } from "@/shared/game/items";
 import { log } from "@/shared/logging";
@@ -355,9 +354,10 @@ export const adminECSUpdateComponentEventHandler = makeEventHandler(
       try {
         let newComponent = entityInvoke(entity, componentField, "mutable");
         if (newComponent === undefined) {
+          // The component can be directly mutated and therefore is not accessed through
+          // mutable accessor method.
           newComponent = entityInvoke(entity, componentField, "get");
         }
-        console.log("newComponent", newComponent);
         const currentValue = fetchCurrentValue(
           newComponent,
           componentLocalPath

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -1,9 +1,9 @@
 import { makeEventHandler } from "@/server/logic/events/core";
 import { q } from "@/server/logic/events/query";
 import {
-  createComponentFromFieldName,
   componentGet,
   componentUpdate,
+  createComponentFromFieldName,
 } from "@/server/logic/utils/components";
 import { entityGet, entityInvoke } from "@/server/logic/utils/delta";
 import {
@@ -261,10 +261,10 @@ export const adminECSDeleteComponentEventHandler = makeEventHandler(
     mergeKey: (event) => event.id,
     involves: (event) => ({
       entity: q.includeIced(event.id),
-      player: q.player(event.userId)
+      player: q.player(event.userId),
     }),
     apply({ entity, player }, { field }, _context) {
-      if (!player.hasRoles('admin')) {
+      if (!player.hasRoles("admin")) {
         throw new Error("not authorized to delete ECS component");
       }
       if (entityGet(entity, field, "get") === undefined) {
@@ -286,11 +286,11 @@ export const adminECSAddComponentEventHandler = makeEventHandler(
     mergeKey: (event) => event.id,
     involves: (event) => ({
       entity: q.includeIced(event.id),
-      player: q.player(event.userId)
+      player: q.player(event.userId),
     }),
     apply({ entity, player }, { field }, _context) {
-      if (!player.hasRoles('admin')) {
-        throw new Error("not authorized to delete ECS component");
+      if (!player.hasRoles("admin")) {
+        throw new Error("not authorized to add ECS component");
       }
       if (entityGet(entity, field, "get") === undefined) {
         throw new Error("attempted to add a component that does not exist");
@@ -325,8 +325,12 @@ export const adminECSUpdateComponentEventHandler = makeEventHandler(
     mergeKey: (event) => event.id,
     involves: (event) => ({
       entity: q.includeIced(event.id),
+      player: q.player(event.userId),
     }),
-    apply({ entity }, { path, value }, _context) {
+    apply({ entity, player }, { path, value }, _context) {
+      if (!player.hasRoles("admin")) {
+        throw new Error("not authorized to update ECS component");
+      }
       if (path.length === 0) {
         throw new Error("invalid edit path");
       }

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -1,5 +1,6 @@
 import { makeEventHandler } from "@/server/logic/events/core";
 import { q } from "@/server/logic/events/query";
+import { entityGet, entityInvoke } from "@/server/logic/utils/delta";
 import {
   copyPlayer,
   ensurePlayerHasReasonablePosition,
@@ -248,52 +249,6 @@ export const adminUpdateInspectionTweaksHandler = makeEventHandler(
     },
   }
 );
-
-type EntityField = keyof Delta;
-
-function snakeCaseToUpperCamalCase(field: string): string {
-  return field
-    .split("_")
-    .map((name) => name[0].toUpperCase() + name.slice(1))
-    .join("");
-}
-
-function snakeCaseToCamalCase(field: string): string {
-  const words = field.split("_");
-  return (
-    words[0] +
-    words
-      .slice(1)
-      .map((name) => name[0].toUpperCase() + name.slice(1))
-      .join("")
-  );
-}
-
-
-type EntityMethod = "get" | "mutable" | "set" | "clear";
-function entityFunc(field: string, method: EntityMethod): EntityField {
-  if (method === "get") {
-    return snakeCaseToCamalCase(field) as EntityField
-  }
-  const componentName = snakeCaseToUpperCamalCase(field);
-  return `${method}${componentName}` as EntityField;
-}
-
-function entityGet(entity: Delta, field: string, method: EntityMethod): any {
-  return entity[entityFunc(field, method)];
-}
-
-function entityInvoke(
-  entity: Delta,
-  field: string,
-  method: "get" | "mutable" | "set" | "clear",
-  ...args: any[]
-): any {
-  if (entity[entityFunc(field, method)] === undefined) {
-    return undefined;
-  }
-  return (entity[entityFunc(field, method)] as any)(...args);
-}
 
 // Delete a component from an entity.
 //

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -12,7 +12,7 @@ import { getBiscuit } from "@/shared/bikkie/active";
 import { secondsSinceEpoch } from "@/shared/ecs/config";
 import * as Component from "@/shared/ecs/gen/components";
 import { RecipeBook } from "@/shared/ecs/gen/components";
-import { Delta } from "@/shared/ecs/gen/delta";
+import type { Delta } from "@/shared/ecs/gen/delta";
 import { anItem } from "@/shared/game/item";
 import { removeFromSet } from "@/shared/game/items";
 import { log } from "@/shared/logging";

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -1,6 +1,10 @@
 import { makeEventHandler } from "@/server/logic/events/core";
 import { q } from "@/server/logic/events/query";
-import { createComponentFromFieldName, componentGet, componentUpdate } from "@/server/logic/utils/components";
+import {
+  createComponentFromFieldName,
+  componentGet,
+  componentUpdate,
+} from "@/server/logic/utils/components";
 import { entityGet, entityInvoke } from "@/server/logic/utils/delta";
 import {
   copyPlayer,

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -292,7 +292,7 @@ export const adminECSAddComponentEventHandler = makeEventHandler(
   }
 );
 
-function fetchCurrentValue(component: any, path: string[]): any {
+function componentGet(component: any, path: string[]): any {
   let current = component;
   for (const key of path) {
     if (current === undefined) {
@@ -304,13 +304,13 @@ function fetchCurrentValue(component: any, path: string[]): any {
   return current;
 }
 
-function updateCurrentValue(component: any, path: string[], value: any) {
+function componentUpdate(component: any, path: string[], newValue: any) {
   let current = component;
   for (let i = 0; i < path.length - 1; ++i) {
     current = component[path[i]];
     ok(current !== undefined);
   }
-  current[path[path.length - 1]] = value;
+  current[path[path.length - 1]] = newValue;
 }
 
 function matchTypeWithExisting(current: any, newValue: string) {
@@ -358,7 +358,7 @@ export const adminECSUpdateComponentEventHandler = makeEventHandler(
           // mutable accessor method.
           newComponent = entityInvoke(entity, componentField, "get");
         }
-        const currentValue = fetchCurrentValue(
+        const currentValue = componentGet(
           newComponent,
           componentLocalPath
         );
@@ -375,7 +375,7 @@ export const adminECSUpdateComponentEventHandler = makeEventHandler(
           throw new Error("invalid new value");
         }
 
-        updateCurrentValue(newComponent, componentLocalPath, newValue);
+        componentUpdate(newComponent, componentLocalPath, newValue);
         // Apply the change to the entity.
         entityInvoke(entity, componentField, "set", newComponent);
       } catch (e) {

--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -261,8 +261,12 @@ export const adminECSDeleteComponentEventHandler = makeEventHandler(
     mergeKey: (event) => event.id,
     involves: (event) => ({
       entity: q.includeIced(event.id),
+      player: q.player(event.userId)
     }),
-    apply({ entity }, { field }, _context) {
+    apply({ entity, player }, { field }, _context) {
+      if (!player.hasRoles('admin')) {
+        throw new Error("not authorized to delete ECS component");
+      }
       if (entityGet(entity, field, "get") === undefined) {
         // Entity does not have the required field.
         throw new Error("field not found");
@@ -282,8 +286,12 @@ export const adminECSAddComponentEventHandler = makeEventHandler(
     mergeKey: (event) => event.id,
     involves: (event) => ({
       entity: q.includeIced(event.id),
+      player: q.player(event.userId)
     }),
-    apply({ entity }, { field }, _context) {
+    apply({ entity, player }, { field }, _context) {
+      if (!player.hasRoles('admin')) {
+        throw new Error("not authorized to delete ECS component");
+      }
       if (entityGet(entity, field, "get") === undefined) {
         throw new Error("attempted to add a component that does not exist");
       }

--- a/src/server/logic/events/player.ts
+++ b/src/server/logic/events/player.ts
@@ -1,7 +1,7 @@
 import { WithInventory } from "@/server/logic/events/with_inventory";
 import { PlayerInventoryEditor } from "@/server/logic/inventory/player_inventory_editor";
 import type { DeltaPatch } from "@/shared/ecs/gen/delta";
-import { UserRole } from "@/shared/ecs/gen/types";
+import type { UserRole } from "@/shared/ecs/gen/types";
 
 export class Player extends WithInventory<PlayerInventoryEditor> {
   constructor(fork: DeltaPatch) {

--- a/src/server/logic/events/player.ts
+++ b/src/server/logic/events/player.ts
@@ -1,6 +1,7 @@
 import { WithInventory } from "@/server/logic/events/with_inventory";
 import { PlayerInventoryEditor } from "@/server/logic/inventory/player_inventory_editor";
 import type { DeltaPatch } from "@/shared/ecs/gen/delta";
+import { UserRole } from "@/shared/ecs/gen/types";
 
 export class Player extends WithInventory<PlayerInventoryEditor> {
   constructor(fork: DeltaPatch) {
@@ -37,5 +38,15 @@ export class Player extends WithInventory<PlayerInventoryEditor> {
 
   roles() {
     return this.fork.userRoles()?.roles;
+  }
+
+  hasRoles(...requiredRoles: UserRole[]): boolean {
+    const roles = this.roles() ?? new Set();
+    for (const role of requiredRoles) {
+      if (!roles.has(role)) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/server/logic/utils/components.ts
+++ b/src/server/logic/utils/components.ts
@@ -2,6 +2,7 @@ import * as Component from "@/shared/ecs/gen/components";
 import { snakeCaseToUpperCamalCase } from "@/shared/util/text";
 import { ok } from "assert";
 
+// Access a field of a component given the path of the field.
 export function componentGet(component: any, path: string[]): any {
   let current = component;
   for (const key of path) {
@@ -14,6 +15,8 @@ export function componentGet(component: any, path: string[]): any {
   return current;
 }
 
+// Update a field of a component given the path of the field and the new value.
+// Throws if the path is invalid.
 export function componentUpdate(component: any, path: string[], newValue: any) {
   let current = component;
   for (let i = 0; i < path.length - 1; ++i) {
@@ -23,6 +26,8 @@ export function componentUpdate(component: any, path: string[], newValue: any) {
   current[path[path.length - 1]] = newValue;
 }
 
+// Creates a default component given the name of the component's field.
+// e.g. "health" -> Component.Health.create()
 export function createComponentFromFieldName(field: string): any {
-  return Component[snakeCaseToUpperCamalCase(field) as unknown as keyof Component].create();
+  return (Component as any)[snakeCaseToUpperCamalCase(field)].create();
 }

--- a/src/server/logic/utils/components.ts
+++ b/src/server/logic/utils/components.ts
@@ -1,0 +1,28 @@
+import * as Component from "@/shared/ecs/gen/components";
+import { snakeCaseToUpperCamalCase } from "@/shared/util/text";
+import { ok } from "assert";
+
+export function componentGet(component: any, path: string[]): any {
+  let current = component;
+  for (const key of path) {
+    if (current === undefined) {
+      return undefined;
+    }
+    current = current[key];
+  }
+
+  return current;
+}
+
+export function componentUpdate(component: any, path: string[], newValue: any) {
+  let current = component;
+  for (let i = 0; i < path.length - 1; ++i) {
+    current = component[path[i]];
+    ok(current !== undefined);
+  }
+  current[path[path.length - 1]] = newValue;
+}
+
+export function createComponentFromFieldName(field: string): any {
+  return Component[snakeCaseToUpperCamalCase(field) as unknown as keyof Component].create();
+}

--- a/src/server/logic/utils/delta.ts
+++ b/src/server/logic/utils/delta.ts
@@ -1,4 +1,4 @@
-import { Delta } from "@/shared/ecs/gen/delta";
+import type { Delta } from "@/shared/ecs/gen/delta";
 
 type EntityField = keyof Delta;
 type EntityMethod = "get" | "mutable" | "set" | "clear";
@@ -29,7 +29,11 @@ function entityFunc(field: string, method: EntityMethod): EntityField {
   return `${method}${componentName}` as EntityField;
 }
 
-export function entityGet(entity: Delta, field: string, method: EntityMethod): any {
+export function entityGet(
+  entity: Delta,
+  field: string,
+  method: EntityMethod
+): any {
   return entity[entityFunc(field, method)];
 }
 

--- a/src/server/logic/utils/delta.ts
+++ b/src/server/logic/utils/delta.ts
@@ -1,5 +1,8 @@
 import type { Delta } from "@/shared/ecs/gen/delta";
-import { snakeCaseToCamalCase, snakeCaseToUpperCamalCase } from "@/shared/util/text";
+import {
+  snakeCaseToCamalCase,
+  snakeCaseToUpperCamalCase,
+} from "@/shared/util/text";
 
 type EntityField = keyof Delta;
 type EntityMethod = "get" | "mutable" | "set" | "clear";

--- a/src/server/logic/utils/delta.ts
+++ b/src/server/logic/utils/delta.ts
@@ -1,0 +1,46 @@
+import { Delta } from "@/shared/ecs/gen/delta";
+
+type EntityField = keyof Delta;
+type EntityMethod = "get" | "mutable" | "set" | "clear";
+
+function snakeCaseToUpperCamalCase(field: string): string {
+  return field
+    .split("_")
+    .map((name) => name[0].toUpperCase() + name.slice(1))
+    .join("");
+}
+
+function snakeCaseToCamalCase(field: string): string {
+  const words = field.split("_");
+  return (
+    words[0] +
+    words
+      .slice(1)
+      .map((name) => name[0].toUpperCase() + name.slice(1))
+      .join("")
+  );
+}
+
+function entityFunc(field: string, method: EntityMethod): EntityField {
+  if (method === "get") {
+    return snakeCaseToCamalCase(field) as EntityField;
+  }
+  const componentName = snakeCaseToUpperCamalCase(field);
+  return `${method}${componentName}` as EntityField;
+}
+
+export function entityGet(entity: Delta, field: string, method: EntityMethod): any {
+  return entity[entityFunc(field, method)];
+}
+
+export function entityInvoke(
+  entity: Delta,
+  field: string,
+  method: "get" | "mutable" | "set" | "clear",
+  ...args: any[]
+): any {
+  if (entity[entityFunc(field, method)] === undefined) {
+    return undefined;
+  }
+  return (entity[entityFunc(field, method)] as any)(...args);
+}

--- a/src/server/logic/utils/delta.ts
+++ b/src/server/logic/utils/delta.ts
@@ -1,25 +1,8 @@
 import type { Delta } from "@/shared/ecs/gen/delta";
+import { snakeCaseToCamalCase, snakeCaseToUpperCamalCase } from "@/shared/util/text";
 
 type EntityField = keyof Delta;
 type EntityMethod = "get" | "mutable" | "set" | "clear";
-
-function snakeCaseToUpperCamalCase(field: string): string {
-  return field
-    .split("_")
-    .map((name) => name[0].toUpperCase() + name.slice(1))
-    .join("");
-}
-
-function snakeCaseToCamalCase(field: string): string {
-  const words = field.split("_");
-  return (
-    words[0] +
-    words
-      .slice(1)
-      .map((name) => name[0].toUpperCase() + name.slice(1))
-      .join("")
-  );
-}
 
 function entityFunc(field: string, method: EntityMethod): EntityField {
   if (method === "get") {

--- a/src/shared/ecs/gen/events.ts
+++ b/src/shared/ecs/gen/events.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from events.ts.j2. Do not modify directly.
-// Content Hash: 0d61c8d86668c78dc44d4bdd0661bd96
+// Content Hash: 20d2d168938b16b056b754e62d7c71e8
 
 import * as t from "@/shared/ecs/gen/types";
 import type { BiomesId } from "@/shared/ids";
@@ -4123,22 +4123,27 @@ export class AdminUpdateInspectionTweaksEvent implements Event {
 export interface HandlerAdminECSDeleteComponentEvent {
   readonly kind: "adminECSDeleteComponentEvent";
   readonly id: BiomesId;
+  readonly userId: BiomesId;
   field: t.String;
 }
 
 export class AdminECSDeleteComponentEvent implements Event {
   readonly kind = "adminECSDeleteComponentEvent";
   readonly id: BiomesId;
+  readonly userId: BiomesId;
   field: t.ReadonlyString;
 
   constructor({
     id = t.defaultBiomesId,
+    userId = t.defaultBiomesId,
     field = t.defaultString,
   }: {
     id?: BiomesId;
+    userId?: BiomesId;
     field?: t.ReadonlyString;
   }) {
     this.id = id;
+    this.userId = userId;
     this.field = field;
   }
 }
@@ -4146,22 +4151,27 @@ export class AdminECSDeleteComponentEvent implements Event {
 export interface HandlerAdminECSAddComponentEvent {
   readonly kind: "adminECSAddComponentEvent";
   readonly id: BiomesId;
+  readonly userId: BiomesId;
   field: t.String;
 }
 
 export class AdminECSAddComponentEvent implements Event {
   readonly kind = "adminECSAddComponentEvent";
   readonly id: BiomesId;
+  readonly userId: BiomesId;
   field: t.ReadonlyString;
 
   constructor({
     id = t.defaultBiomesId,
+    userId = t.defaultBiomesId,
     field = t.defaultString,
   }: {
     id?: BiomesId;
+    userId?: BiomesId;
     field?: t.ReadonlyString;
   }) {
     this.id = id;
+    this.userId = userId;
     this.field = field;
   }
 }
@@ -4169,6 +4179,7 @@ export class AdminECSAddComponentEvent implements Event {
 export interface HandlerAdminECSUpdateComponentEvent {
   readonly kind: "adminECSUpdateComponentEvent";
   readonly id: BiomesId;
+  readonly userId: BiomesId;
   path: t.Strings;
   value: t.String;
 }
@@ -4176,19 +4187,23 @@ export interface HandlerAdminECSUpdateComponentEvent {
 export class AdminECSUpdateComponentEvent implements Event {
   readonly kind = "adminECSUpdateComponentEvent";
   readonly id: BiomesId;
+  readonly userId: BiomesId;
   path: t.ReadonlyStrings;
   value: t.ReadonlyString;
 
   constructor({
     id = t.defaultBiomesId,
+    userId = t.defaultBiomesId,
     path = t.defaultStrings(),
     value = t.defaultString,
   }: {
     id?: BiomesId;
+    userId?: BiomesId;
     path?: t.ReadonlyStrings;
     value?: t.ReadonlyString;
   }) {
     this.id = id;
+    this.userId = userId;
     this.path = path;
     this.value = value;
   }

--- a/src/shared/ecs/gen/events.ts
+++ b/src/shared/ecs/gen/events.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from events.ts.j2. Do not modify directly.
-// Content Hash: 3ab642717a28de3f6b692bf73a8098fa
+// Content Hash: 0d61c8d86668c78dc44d4bdd0661bd96
 
 import * as t from "@/shared/ecs/gen/types";
 import type { BiomesId } from "@/shared/ids";
@@ -133,6 +133,7 @@ export interface EventSet {
   readonly adminUpdateInspectionTweaksEvent?: AdminUpdateInspectionTweaksEvent[];
   readonly adminECSDeleteComponentEvent?: AdminECSDeleteComponentEvent[];
   readonly adminECSAddComponentEvent?: AdminECSAddComponentEvent[];
+  readonly adminECSUpdateComponentEvent?: AdminECSUpdateComponentEvent[];
   readonly createTeamEvent?: CreateTeamEvent[];
   readonly updateTeamMetadataEvent?: UpdateTeamMetadataEvent[];
   readonly invitePlayerToTeamEvent?: InvitePlayerToTeamEvent[];
@@ -287,6 +288,7 @@ interface SuperEventSet {
   readonly adminUpdateInspectionTweaksEvent: AdminUpdateInspectionTweaksEvent[];
   readonly adminECSDeleteComponentEvent: AdminECSDeleteComponentEvent[];
   readonly adminECSAddComponentEvent: AdminECSAddComponentEvent[];
+  readonly adminECSUpdateComponentEvent: AdminECSUpdateComponentEvent[];
   readonly createTeamEvent: CreateTeamEvent[];
   readonly updateTeamMetadataEvent: UpdateTeamMetadataEvent[];
   readonly invitePlayerToTeamEvent: InvitePlayerToTeamEvent[];
@@ -4164,6 +4166,34 @@ export class AdminECSAddComponentEvent implements Event {
   }
 }
 
+export interface HandlerAdminECSUpdateComponentEvent {
+  readonly kind: "adminECSUpdateComponentEvent";
+  readonly id: BiomesId;
+  path: t.Strings;
+  value: t.String;
+}
+
+export class AdminECSUpdateComponentEvent implements Event {
+  readonly kind = "adminECSUpdateComponentEvent";
+  readonly id: BiomesId;
+  path: t.ReadonlyStrings;
+  value: t.ReadonlyString;
+
+  constructor({
+    id = t.defaultBiomesId,
+    path = t.defaultStrings(),
+    value = t.defaultString,
+  }: {
+    id?: BiomesId;
+    path?: t.ReadonlyStrings;
+    value?: t.ReadonlyString;
+  }) {
+    this.id = id;
+    this.path = path;
+    this.value = value;
+  }
+}
+
 export interface HandlerCreateTeamEvent {
   readonly kind: "createTeamEvent";
   readonly id: BiomesId;
@@ -4924,6 +4954,7 @@ export type AnyHandlerEvent =
   | HandlerAdminUpdateInspectionTweaksEvent
   | HandlerAdminECSDeleteComponentEvent
   | HandlerAdminECSAddComponentEvent
+  | HandlerAdminECSUpdateComponentEvent
   | HandlerCreateTeamEvent
   | HandlerUpdateTeamMetadataEvent
   | HandlerInvitePlayerToTeamEvent
@@ -5077,6 +5108,7 @@ export type AnyEvent =
   | AdminUpdateInspectionTweaksEvent
   | AdminECSDeleteComponentEvent
   | AdminECSAddComponentEvent
+  | AdminECSUpdateComponentEvent
   | CreateTeamEvent
   | UpdateTeamMetadataEvent
   | InvitePlayerToTeamEvent

--- a/src/shared/ecs/gen/events.ts
+++ b/src/shared/ecs/gen/events.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from events.ts.j2. Do not modify directly.
-// Content Hash: bd63396e755b5ec5777541856fd9ab29
+// Content Hash: 3ab642717a28de3f6b692bf73a8098fa
 
 import * as t from "@/shared/ecs/gen/types";
 import type { BiomesId } from "@/shared/ids";
@@ -131,8 +131,8 @@ export interface EventSet {
   readonly sellToEntityEvent?: SellToEntityEvent[];
   readonly setNPCPositionEvent?: SetNPCPositionEvent[];
   readonly adminUpdateInspectionTweaksEvent?: AdminUpdateInspectionTweaksEvent[];
-  readonly adminECSDeleteFieldEvent?: AdminECSDeleteFieldEvent[];
-  readonly adminECSAddFieldEvent?: AdminECSAddFieldEvent[];
+  readonly adminECSDeleteComponentEvent?: AdminECSDeleteComponentEvent[];
+  readonly adminECSAddComponentEvent?: AdminECSAddComponentEvent[];
   readonly createTeamEvent?: CreateTeamEvent[];
   readonly updateTeamMetadataEvent?: UpdateTeamMetadataEvent[];
   readonly invitePlayerToTeamEvent?: InvitePlayerToTeamEvent[];
@@ -285,8 +285,8 @@ interface SuperEventSet {
   readonly sellToEntityEvent: SellToEntityEvent[];
   readonly setNPCPositionEvent: SetNPCPositionEvent[];
   readonly adminUpdateInspectionTweaksEvent: AdminUpdateInspectionTweaksEvent[];
-  readonly adminECSDeleteFieldEvent: AdminECSDeleteFieldEvent[];
-  readonly adminECSAddFieldEvent: AdminECSAddFieldEvent[];
+  readonly adminECSDeleteComponentEvent: AdminECSDeleteComponentEvent[];
+  readonly adminECSAddComponentEvent: AdminECSAddComponentEvent[];
   readonly createTeamEvent: CreateTeamEvent[];
   readonly updateTeamMetadataEvent: UpdateTeamMetadataEvent[];
   readonly invitePlayerToTeamEvent: InvitePlayerToTeamEvent[];
@@ -4118,14 +4118,14 @@ export class AdminUpdateInspectionTweaksEvent implements Event {
   }
 }
 
-export interface HandlerAdminECSDeleteFieldEvent {
-  readonly kind: "adminECSDeleteFieldEvent";
+export interface HandlerAdminECSDeleteComponentEvent {
+  readonly kind: "adminECSDeleteComponentEvent";
   readonly id: BiomesId;
   field: t.String;
 }
 
-export class AdminECSDeleteFieldEvent implements Event {
-  readonly kind = "adminECSDeleteFieldEvent";
+export class AdminECSDeleteComponentEvent implements Event {
+  readonly kind = "adminECSDeleteComponentEvent";
   readonly id: BiomesId;
   field: t.ReadonlyString;
 
@@ -4141,14 +4141,14 @@ export class AdminECSDeleteFieldEvent implements Event {
   }
 }
 
-export interface HandlerAdminECSAddFieldEvent {
-  readonly kind: "adminECSAddFieldEvent";
+export interface HandlerAdminECSAddComponentEvent {
+  readonly kind: "adminECSAddComponentEvent";
   readonly id: BiomesId;
   field: t.String;
 }
 
-export class AdminECSAddFieldEvent implements Event {
-  readonly kind = "adminECSAddFieldEvent";
+export class AdminECSAddComponentEvent implements Event {
+  readonly kind = "adminECSAddComponentEvent";
   readonly id: BiomesId;
   field: t.ReadonlyString;
 
@@ -4922,8 +4922,8 @@ export type AnyHandlerEvent =
   | HandlerSellToEntityEvent
   | HandlerSetNPCPositionEvent
   | HandlerAdminUpdateInspectionTweaksEvent
-  | HandlerAdminECSDeleteFieldEvent
-  | HandlerAdminECSAddFieldEvent
+  | HandlerAdminECSDeleteComponentEvent
+  | HandlerAdminECSAddComponentEvent
   | HandlerCreateTeamEvent
   | HandlerUpdateTeamMetadataEvent
   | HandlerInvitePlayerToTeamEvent
@@ -5075,8 +5075,8 @@ export type AnyEvent =
   | SellToEntityEvent
   | SetNPCPositionEvent
   | AdminUpdateInspectionTweaksEvent
-  | AdminECSDeleteFieldEvent
-  | AdminECSAddFieldEvent
+  | AdminECSDeleteComponentEvent
+  | AdminECSAddComponentEvent
   | CreateTeamEvent
   | UpdateTeamMetadataEvent
   | InvitePlayerToTeamEvent

--- a/src/shared/ecs/gen/events.ts
+++ b/src/shared/ecs/gen/events.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from events.ts.j2. Do not modify directly.
-// Content Hash: cabd1bb9ec8963ae5794d3330bfcdf4e
+// Content Hash: bd63396e755b5ec5777541856fd9ab29
 
 import * as t from "@/shared/ecs/gen/types";
 import type { BiomesId } from "@/shared/ids";
@@ -131,6 +131,8 @@ export interface EventSet {
   readonly sellToEntityEvent?: SellToEntityEvent[];
   readonly setNPCPositionEvent?: SetNPCPositionEvent[];
   readonly adminUpdateInspectionTweaksEvent?: AdminUpdateInspectionTweaksEvent[];
+  readonly adminECSDeleteFieldEvent?: AdminECSDeleteFieldEvent[];
+  readonly adminECSAddFieldEvent?: AdminECSAddFieldEvent[];
   readonly createTeamEvent?: CreateTeamEvent[];
   readonly updateTeamMetadataEvent?: UpdateTeamMetadataEvent[];
   readonly invitePlayerToTeamEvent?: InvitePlayerToTeamEvent[];
@@ -283,6 +285,8 @@ interface SuperEventSet {
   readonly sellToEntityEvent: SellToEntityEvent[];
   readonly setNPCPositionEvent: SetNPCPositionEvent[];
   readonly adminUpdateInspectionTweaksEvent: AdminUpdateInspectionTweaksEvent[];
+  readonly adminECSDeleteFieldEvent: AdminECSDeleteFieldEvent[];
+  readonly adminECSAddFieldEvent: AdminECSAddFieldEvent[];
   readonly createTeamEvent: CreateTeamEvent[];
   readonly updateTeamMetadataEvent: UpdateTeamMetadataEvent[];
   readonly invitePlayerToTeamEvent: InvitePlayerToTeamEvent[];
@@ -4114,6 +4118,52 @@ export class AdminUpdateInspectionTweaksEvent implements Event {
   }
 }
 
+export interface HandlerAdminECSDeleteFieldEvent {
+  readonly kind: "adminECSDeleteFieldEvent";
+  readonly id: BiomesId;
+  field: t.String;
+}
+
+export class AdminECSDeleteFieldEvent implements Event {
+  readonly kind = "adminECSDeleteFieldEvent";
+  readonly id: BiomesId;
+  field: t.ReadonlyString;
+
+  constructor({
+    id = t.defaultBiomesId,
+    field = t.defaultString,
+  }: {
+    id?: BiomesId;
+    field?: t.ReadonlyString;
+  }) {
+    this.id = id;
+    this.field = field;
+  }
+}
+
+export interface HandlerAdminECSAddFieldEvent {
+  readonly kind: "adminECSAddFieldEvent";
+  readonly id: BiomesId;
+  field: t.String;
+}
+
+export class AdminECSAddFieldEvent implements Event {
+  readonly kind = "adminECSAddFieldEvent";
+  readonly id: BiomesId;
+  field: t.ReadonlyString;
+
+  constructor({
+    id = t.defaultBiomesId,
+    field = t.defaultString,
+  }: {
+    id?: BiomesId;
+    field?: t.ReadonlyString;
+  }) {
+    this.id = id;
+    this.field = field;
+  }
+}
+
 export interface HandlerCreateTeamEvent {
   readonly kind: "createTeamEvent";
   readonly id: BiomesId;
@@ -4698,7 +4748,6 @@ export interface HandlerAddToOutfitEvent {
   readonly kind: "addToOutfitEvent";
   readonly id: BiomesId;
   readonly player_id: BiomesId;
-  readonly src_id: BiomesId;
   src: t.OwnedItemReference;
 }
 
@@ -4706,23 +4755,19 @@ export class AddToOutfitEvent implements Event {
   readonly kind = "addToOutfitEvent";
   readonly id: BiomesId;
   readonly player_id: BiomesId;
-  readonly src_id: BiomesId;
   src: t.ReadonlyOwnedItemReference;
 
   constructor({
     id = t.defaultBiomesId,
     player_id = t.defaultBiomesId,
-    src_id = t.defaultBiomesId,
     src = t.defaultOwnedItemReference(),
   }: {
     id?: BiomesId;
     player_id?: BiomesId;
-    src_id?: BiomesId;
     src?: t.ReadonlyOwnedItemReference;
   }) {
     this.id = id;
     this.player_id = player_id;
-    this.src_id = src_id;
     this.src = src;
   }
 }
@@ -4877,6 +4922,8 @@ export type AnyHandlerEvent =
   | HandlerSellToEntityEvent
   | HandlerSetNPCPositionEvent
   | HandlerAdminUpdateInspectionTweaksEvent
+  | HandlerAdminECSDeleteFieldEvent
+  | HandlerAdminECSAddFieldEvent
   | HandlerCreateTeamEvent
   | HandlerUpdateTeamMetadataEvent
   | HandlerInvitePlayerToTeamEvent
@@ -5028,6 +5075,8 @@ export type AnyEvent =
   | SellToEntityEvent
   | SetNPCPositionEvent
   | AdminUpdateInspectionTweaksEvent
+  | AdminECSDeleteFieldEvent
+  | AdminECSAddFieldEvent
   | CreateTeamEvent
   | UpdateTeamMetadataEvent
   | InvitePlayerToTeamEvent

--- a/src/shared/ecs/gen/json_serde.ts
+++ b/src/shared/ecs/gen/json_serde.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from json_serde.ts.j2. Do not modify directly.
-// Content Hash: fc42476112110b6097a0d1c04b0b9aca
+// Content Hash: d6c613c814e365dbcf2820abc591f53f
 
 import * as c from "@/shared/ecs/gen/components";
 import * as e from "@/shared/ecs/gen/entities";
@@ -10343,6 +10343,38 @@ class AdminUpdateInspectionTweaksEventSerde {
     });
   }
 }
+class AdminECSDeleteFieldEventSerde {
+  static serialize(event: ev.AdminECSDeleteFieldEvent) {
+    return {
+      kind: "adminECSDeleteFieldEvent",
+      id: t.serializeBiomesId(event.id),
+      field: event.field,
+    };
+  }
+
+  static deserialize(data: any) {
+    return new ev.AdminECSDeleteFieldEvent({
+      id: t.deserializeBiomesId(data.id),
+      field: t.deserializeString(data.field),
+    });
+  }
+}
+class AdminECSAddFieldEventSerde {
+  static serialize(event: ev.AdminECSAddFieldEvent) {
+    return {
+      kind: "adminECSAddFieldEvent",
+      id: t.serializeBiomesId(event.id),
+      field: event.field,
+    };
+  }
+
+  static deserialize(data: any) {
+    return new ev.AdminECSAddFieldEvent({
+      id: t.deserializeBiomesId(data.id),
+      field: t.deserializeString(data.field),
+    });
+  }
+}
 class CreateTeamEventSerde {
   static serialize(event: ev.CreateTeamEvent) {
     return {
@@ -10727,7 +10759,6 @@ class AddToOutfitEventSerde {
       kind: "addToOutfitEvent",
       id: t.serializeBiomesId(event.id),
       player_id: t.serializeBiomesId(event.player_id),
-      src_id: t.serializeBiomesId(event.src_id),
       src: t.serializeOwnedItemReference(event.src),
     };
   }
@@ -10736,7 +10767,6 @@ class AddToOutfitEventSerde {
     return new ev.AddToOutfitEvent({
       id: t.deserializeBiomesId(data.id),
       player_id: t.deserializeBiomesId(data.player_id),
-      src_id: t.deserializeBiomesId(data.src_id),
       src: t.deserializeOwnedItemReference(data.src),
     });
   }
@@ -11175,6 +11205,14 @@ export class EventSerde {
         return AdminUpdateInspectionTweaksEventSerde.serialize(
           event as ev.AdminUpdateInspectionTweaksEvent
         );
+      case "adminECSDeleteFieldEvent":
+        return AdminECSDeleteFieldEventSerde.serialize(
+          event as ev.AdminECSDeleteFieldEvent
+        );
+      case "adminECSAddFieldEvent":
+        return AdminECSAddFieldEventSerde.serialize(
+          event as ev.AdminECSAddFieldEvent
+        );
       case "createTeamEvent":
         return CreateTeamEventSerde.serialize(event as ev.CreateTeamEvent);
       case "updateTeamMetadataEvent":
@@ -11505,6 +11543,10 @@ export class EventSerde {
         return SetNPCPositionEventSerde.deserialize(data);
       case "adminUpdateInspectionTweaksEvent":
         return AdminUpdateInspectionTweaksEventSerde.deserialize(data);
+      case "adminECSDeleteFieldEvent":
+        return AdminECSDeleteFieldEventSerde.deserialize(data);
+      case "adminECSAddFieldEvent":
+        return AdminECSAddFieldEventSerde.deserialize(data);
       case "createTeamEvent":
         return CreateTeamEventSerde.deserialize(data);
       case "updateTeamMetadataEvent":

--- a/src/shared/ecs/gen/json_serde.ts
+++ b/src/shared/ecs/gen/json_serde.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from json_serde.ts.j2. Do not modify directly.
-// Content Hash: d6c613c814e365dbcf2820abc591f53f
+// Content Hash: f65afb62330b6b177cd3491214fcf78d
 
 import * as c from "@/shared/ecs/gen/components";
 import * as e from "@/shared/ecs/gen/entities";
@@ -10343,33 +10343,33 @@ class AdminUpdateInspectionTweaksEventSerde {
     });
   }
 }
-class AdminECSDeleteFieldEventSerde {
-  static serialize(event: ev.AdminECSDeleteFieldEvent) {
+class AdminECSDeleteComponentEventSerde {
+  static serialize(event: ev.AdminECSDeleteComponentEvent) {
     return {
-      kind: "adminECSDeleteFieldEvent",
+      kind: "adminECSDeleteComponentEvent",
       id: t.serializeBiomesId(event.id),
       field: event.field,
     };
   }
 
   static deserialize(data: any) {
-    return new ev.AdminECSDeleteFieldEvent({
+    return new ev.AdminECSDeleteComponentEvent({
       id: t.deserializeBiomesId(data.id),
       field: t.deserializeString(data.field),
     });
   }
 }
-class AdminECSAddFieldEventSerde {
-  static serialize(event: ev.AdminECSAddFieldEvent) {
+class AdminECSAddComponentEventSerde {
+  static serialize(event: ev.AdminECSAddComponentEvent) {
     return {
-      kind: "adminECSAddFieldEvent",
+      kind: "adminECSAddComponentEvent",
       id: t.serializeBiomesId(event.id),
       field: event.field,
     };
   }
 
   static deserialize(data: any) {
-    return new ev.AdminECSAddFieldEvent({
+    return new ev.AdminECSAddComponentEvent({
       id: t.deserializeBiomesId(data.id),
       field: t.deserializeString(data.field),
     });
@@ -11205,13 +11205,13 @@ export class EventSerde {
         return AdminUpdateInspectionTweaksEventSerde.serialize(
           event as ev.AdminUpdateInspectionTweaksEvent
         );
-      case "adminECSDeleteFieldEvent":
-        return AdminECSDeleteFieldEventSerde.serialize(
-          event as ev.AdminECSDeleteFieldEvent
+      case "adminECSDeleteComponentEvent":
+        return AdminECSDeleteComponentEventSerde.serialize(
+          event as ev.AdminECSDeleteComponentEvent
         );
-      case "adminECSAddFieldEvent":
-        return AdminECSAddFieldEventSerde.serialize(
-          event as ev.AdminECSAddFieldEvent
+      case "adminECSAddComponentEvent":
+        return AdminECSAddComponentEventSerde.serialize(
+          event as ev.AdminECSAddComponentEvent
         );
       case "createTeamEvent":
         return CreateTeamEventSerde.serialize(event as ev.CreateTeamEvent);
@@ -11543,10 +11543,10 @@ export class EventSerde {
         return SetNPCPositionEventSerde.deserialize(data);
       case "adminUpdateInspectionTweaksEvent":
         return AdminUpdateInspectionTweaksEventSerde.deserialize(data);
-      case "adminECSDeleteFieldEvent":
-        return AdminECSDeleteFieldEventSerde.deserialize(data);
-      case "adminECSAddFieldEvent":
-        return AdminECSAddFieldEventSerde.deserialize(data);
+      case "adminECSDeleteComponentEvent":
+        return AdminECSDeleteComponentEventSerde.deserialize(data);
+      case "adminECSAddComponentEvent":
+        return AdminECSAddComponentEventSerde.deserialize(data);
       case "createTeamEvent":
         return CreateTeamEventSerde.deserialize(data);
       case "updateTeamMetadataEvent":

--- a/src/shared/ecs/gen/json_serde.ts
+++ b/src/shared/ecs/gen/json_serde.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from json_serde.ts.j2. Do not modify directly.
-// Content Hash: f65afb62330b6b177cd3491214fcf78d
+// Content Hash: ecbe8bb6b662225f526e939b2f7af9ee
 
 import * as c from "@/shared/ecs/gen/components";
 import * as e from "@/shared/ecs/gen/entities";
@@ -10375,6 +10375,24 @@ class AdminECSAddComponentEventSerde {
     });
   }
 }
+class AdminECSUpdateComponentEventSerde {
+  static serialize(event: ev.AdminECSUpdateComponentEvent) {
+    return {
+      kind: "adminECSUpdateComponentEvent",
+      id: t.serializeBiomesId(event.id),
+      path: event.path,
+      value: event.value,
+    };
+  }
+
+  static deserialize(data: any) {
+    return new ev.AdminECSUpdateComponentEvent({
+      id: t.deserializeBiomesId(data.id),
+      path: t.deserializeStrings(data.path),
+      value: t.deserializeString(data.value),
+    });
+  }
+}
 class CreateTeamEventSerde {
   static serialize(event: ev.CreateTeamEvent) {
     return {
@@ -11213,6 +11231,10 @@ export class EventSerde {
         return AdminECSAddComponentEventSerde.serialize(
           event as ev.AdminECSAddComponentEvent
         );
+      case "adminECSUpdateComponentEvent":
+        return AdminECSUpdateComponentEventSerde.serialize(
+          event as ev.AdminECSUpdateComponentEvent
+        );
       case "createTeamEvent":
         return CreateTeamEventSerde.serialize(event as ev.CreateTeamEvent);
       case "updateTeamMetadataEvent":
@@ -11547,6 +11569,8 @@ export class EventSerde {
         return AdminECSDeleteComponentEventSerde.deserialize(data);
       case "adminECSAddComponentEvent":
         return AdminECSAddComponentEventSerde.deserialize(data);
+      case "adminECSUpdateComponentEvent":
+        return AdminECSUpdateComponentEventSerde.deserialize(data);
       case "createTeamEvent":
         return CreateTeamEventSerde.deserialize(data);
       case "updateTeamMetadataEvent":

--- a/src/shared/ecs/gen/json_serde.ts
+++ b/src/shared/ecs/gen/json_serde.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from json_serde.ts.j2. Do not modify directly.
-// Content Hash: ecbe8bb6b662225f526e939b2f7af9ee
+// Content Hash: 00457510e3f497fddb442970e29931a9
 
 import * as c from "@/shared/ecs/gen/components";
 import * as e from "@/shared/ecs/gen/entities";
@@ -10348,6 +10348,7 @@ class AdminECSDeleteComponentEventSerde {
     return {
       kind: "adminECSDeleteComponentEvent",
       id: t.serializeBiomesId(event.id),
+      userId: t.serializeBiomesId(event.userId),
       field: event.field,
     };
   }
@@ -10355,6 +10356,7 @@ class AdminECSDeleteComponentEventSerde {
   static deserialize(data: any) {
     return new ev.AdminECSDeleteComponentEvent({
       id: t.deserializeBiomesId(data.id),
+      userId: t.deserializeBiomesId(data.userId),
       field: t.deserializeString(data.field),
     });
   }
@@ -10364,6 +10366,7 @@ class AdminECSAddComponentEventSerde {
     return {
       kind: "adminECSAddComponentEvent",
       id: t.serializeBiomesId(event.id),
+      userId: t.serializeBiomesId(event.userId),
       field: event.field,
     };
   }
@@ -10371,6 +10374,7 @@ class AdminECSAddComponentEventSerde {
   static deserialize(data: any) {
     return new ev.AdminECSAddComponentEvent({
       id: t.deserializeBiomesId(data.id),
+      userId: t.deserializeBiomesId(data.userId),
       field: t.deserializeString(data.field),
     });
   }
@@ -10380,6 +10384,7 @@ class AdminECSUpdateComponentEventSerde {
     return {
       kind: "adminECSUpdateComponentEvent",
       id: t.serializeBiomesId(event.id),
+      userId: t.serializeBiomesId(event.userId),
       path: event.path,
       value: event.value,
     };
@@ -10388,6 +10393,7 @@ class AdminECSUpdateComponentEventSerde {
   static deserialize(data: any) {
     return new ev.AdminECSUpdateComponentEvent({
       id: t.deserializeBiomesId(data.id),
+      userId: t.deserializeBiomesId(data.userId),
       path: t.deserializeStrings(data.path),
       value: t.deserializeString(data.value),
     });

--- a/src/shared/ecs/gen/types.ts
+++ b/src/shared/ecs/gen/types.ts
@@ -1,6 +1,62 @@
 // GENERATED: This file is generated from types.ts.j2. Do not modify directly.
-// Content Hash: 0dd4287071a815484502bc6a1fd15eda
+// Content Hash: aed777d4bcdfbe670f7a484dbc08b7db
 
+export type { Item, ReadonlyItem } from "@/shared/ecs/extern";
+export {
+  zItem,
+  defaultItem,
+  serializeItem,
+  deserializeItem,
+} from "@/shared/ecs/extern";
+import {
+  Item,
+  ReadonlyItem,
+  zItem,
+  defaultItem,
+  serializeItem,
+  deserializeItem,
+} from "@/shared/ecs/extern";
+export type { ItemAndCount, ReadonlyItemAndCount } from "@/shared/ecs/extern";
+export {
+  zItemAndCount,
+  defaultItemAndCount,
+  serializeItemAndCount,
+  deserializeItemAndCount,
+} from "@/shared/ecs/extern";
+import {
+  ItemAndCount,
+  ReadonlyItemAndCount,
+  zItemAndCount,
+  defaultItemAndCount,
+  serializeItemAndCount,
+  deserializeItemAndCount,
+} from "@/shared/ecs/extern";
+import { ReadonlyBiomesId, BiomesId, zBiomesId } from "@/shared/ids";
+import {
+  defaultBiomesId,
+  serializeBiomesId,
+  deserializeBiomesId,
+} from "@/shared/ecs/extern";
+export {
+  defaultBiomesId,
+  serializeBiomesId,
+  deserializeBiomesId,
+} from "@/shared/ecs/extern";
+export type { ShardId, ReadonlyShardId } from "@/shared/ecs/extern";
+export {
+  zShardId,
+  defaultShardId,
+  serializeShardId,
+  deserializeShardId,
+} from "@/shared/ecs/extern";
+import {
+  ShardId,
+  ReadonlyShardId,
+  zShardId,
+  defaultShardId,
+  serializeShardId,
+  deserializeShardId,
+} from "@/shared/ecs/extern";
 export type {
   TriggerStateMap,
   ReadonlyTriggerStateMap,
@@ -18,62 +74,6 @@ import {
   defaultTriggerStateMap,
   serializeTriggerStateMap,
   deserializeTriggerStateMap,
-} from "@/shared/ecs/extern";
-export type { ShardId, ReadonlyShardId } from "@/shared/ecs/extern";
-export {
-  zShardId,
-  defaultShardId,
-  serializeShardId,
-  deserializeShardId,
-} from "@/shared/ecs/extern";
-import {
-  ShardId,
-  ReadonlyShardId,
-  zShardId,
-  defaultShardId,
-  serializeShardId,
-  deserializeShardId,
-} from "@/shared/ecs/extern";
-export type { ItemAndCount, ReadonlyItemAndCount } from "@/shared/ecs/extern";
-export {
-  zItemAndCount,
-  defaultItemAndCount,
-  serializeItemAndCount,
-  deserializeItemAndCount,
-} from "@/shared/ecs/extern";
-import {
-  ItemAndCount,
-  ReadonlyItemAndCount,
-  zItemAndCount,
-  defaultItemAndCount,
-  serializeItemAndCount,
-  deserializeItemAndCount,
-} from "@/shared/ecs/extern";
-export type { Item, ReadonlyItem } from "@/shared/ecs/extern";
-export {
-  zItem,
-  defaultItem,
-  serializeItem,
-  deserializeItem,
-} from "@/shared/ecs/extern";
-import {
-  Item,
-  ReadonlyItem,
-  zItem,
-  defaultItem,
-  serializeItem,
-  deserializeItem,
-} from "@/shared/ecs/extern";
-import { ReadonlyBiomesId, BiomesId, zBiomesId } from "@/shared/ids";
-import {
-  defaultBiomesId,
-  serializeBiomesId,
-  deserializeBiomesId,
-} from "@/shared/ecs/extern";
-export {
-  defaultBiomesId,
-  serializeBiomesId,
-  deserializeBiomesId,
 } from "@/shared/ecs/extern";
 import { z } from "zod";
 import { isInteger } from "lodash";

--- a/src/shared/ecs/gen/types.ts
+++ b/src/shared/ecs/gen/types.ts
@@ -1,62 +1,6 @@
 // GENERATED: This file is generated from types.ts.j2. Do not modify directly.
-// Content Hash: aa9659702466800f0ad62ba9d57633dc
+// Content Hash: dcefee8d32b3384b38e177e3cb45e019
 
-export type { Item, ReadonlyItem } from "@/shared/ecs/extern";
-export {
-  zItem,
-  defaultItem,
-  serializeItem,
-  deserializeItem,
-} from "@/shared/ecs/extern";
-import {
-  Item,
-  ReadonlyItem,
-  zItem,
-  defaultItem,
-  serializeItem,
-  deserializeItem,
-} from "@/shared/ecs/extern";
-export type { ShardId, ReadonlyShardId } from "@/shared/ecs/extern";
-export {
-  zShardId,
-  defaultShardId,
-  serializeShardId,
-  deserializeShardId,
-} from "@/shared/ecs/extern";
-import {
-  ShardId,
-  ReadonlyShardId,
-  zShardId,
-  defaultShardId,
-  serializeShardId,
-  deserializeShardId,
-} from "@/shared/ecs/extern";
-export type { ItemAndCount, ReadonlyItemAndCount } from "@/shared/ecs/extern";
-export {
-  zItemAndCount,
-  defaultItemAndCount,
-  serializeItemAndCount,
-  deserializeItemAndCount,
-} from "@/shared/ecs/extern";
-import {
-  ItemAndCount,
-  ReadonlyItemAndCount,
-  zItemAndCount,
-  defaultItemAndCount,
-  serializeItemAndCount,
-  deserializeItemAndCount,
-} from "@/shared/ecs/extern";
-import { ReadonlyBiomesId, BiomesId, zBiomesId } from "@/shared/ids";
-import {
-  defaultBiomesId,
-  serializeBiomesId,
-  deserializeBiomesId,
-} from "@/shared/ecs/extern";
-export {
-  defaultBiomesId,
-  serializeBiomesId,
-  deserializeBiomesId,
-} from "@/shared/ecs/extern";
 export type {
   TriggerStateMap,
   ReadonlyTriggerStateMap,
@@ -74,6 +18,62 @@ import {
   defaultTriggerStateMap,
   serializeTriggerStateMap,
   deserializeTriggerStateMap,
+} from "@/shared/ecs/extern";
+import { ReadonlyBiomesId, BiomesId, zBiomesId } from "@/shared/ids";
+import {
+  defaultBiomesId,
+  serializeBiomesId,
+  deserializeBiomesId,
+} from "@/shared/ecs/extern";
+export {
+  defaultBiomesId,
+  serializeBiomesId,
+  deserializeBiomesId,
+} from "@/shared/ecs/extern";
+export type { ItemAndCount, ReadonlyItemAndCount } from "@/shared/ecs/extern";
+export {
+  zItemAndCount,
+  defaultItemAndCount,
+  serializeItemAndCount,
+  deserializeItemAndCount,
+} from "@/shared/ecs/extern";
+import {
+  ItemAndCount,
+  ReadonlyItemAndCount,
+  zItemAndCount,
+  defaultItemAndCount,
+  serializeItemAndCount,
+  deserializeItemAndCount,
+} from "@/shared/ecs/extern";
+export type { ShardId, ReadonlyShardId } from "@/shared/ecs/extern";
+export {
+  zShardId,
+  defaultShardId,
+  serializeShardId,
+  deserializeShardId,
+} from "@/shared/ecs/extern";
+import {
+  ShardId,
+  ReadonlyShardId,
+  zShardId,
+  defaultShardId,
+  serializeShardId,
+  deserializeShardId,
+} from "@/shared/ecs/extern";
+export type { Item, ReadonlyItem } from "@/shared/ecs/extern";
+export {
+  zItem,
+  defaultItem,
+  serializeItem,
+  deserializeItem,
+} from "@/shared/ecs/extern";
+import {
+  Item,
+  ReadonlyItem,
+  zItem,
+  defaultItem,
+  serializeItem,
+  deserializeItem,
 } from "@/shared/ecs/extern";
 import { z } from "zod";
 import { isInteger } from "lodash";

--- a/src/shared/ecs/gen/types.ts
+++ b/src/shared/ecs/gen/types.ts
@@ -1,5 +1,5 @@
 // GENERATED: This file is generated from types.ts.j2. Do not modify directly.
-// Content Hash: dcefee8d32b3384b38e177e3cb45e019
+// Content Hash: 0dd4287071a815484502bc6a1fd15eda
 
 export type {
   TriggerStateMap,
@@ -19,16 +19,20 @@ import {
   serializeTriggerStateMap,
   deserializeTriggerStateMap,
 } from "@/shared/ecs/extern";
-import { ReadonlyBiomesId, BiomesId, zBiomesId } from "@/shared/ids";
-import {
-  defaultBiomesId,
-  serializeBiomesId,
-  deserializeBiomesId,
-} from "@/shared/ecs/extern";
+export type { ShardId, ReadonlyShardId } from "@/shared/ecs/extern";
 export {
-  defaultBiomesId,
-  serializeBiomesId,
-  deserializeBiomesId,
+  zShardId,
+  defaultShardId,
+  serializeShardId,
+  deserializeShardId,
+} from "@/shared/ecs/extern";
+import {
+  ShardId,
+  ReadonlyShardId,
+  zShardId,
+  defaultShardId,
+  serializeShardId,
+  deserializeShardId,
 } from "@/shared/ecs/extern";
 export type { ItemAndCount, ReadonlyItemAndCount } from "@/shared/ecs/extern";
 export {
@@ -45,21 +49,6 @@ import {
   serializeItemAndCount,
   deserializeItemAndCount,
 } from "@/shared/ecs/extern";
-export type { ShardId, ReadonlyShardId } from "@/shared/ecs/extern";
-export {
-  zShardId,
-  defaultShardId,
-  serializeShardId,
-  deserializeShardId,
-} from "@/shared/ecs/extern";
-import {
-  ShardId,
-  ReadonlyShardId,
-  zShardId,
-  defaultShardId,
-  serializeShardId,
-  deserializeShardId,
-} from "@/shared/ecs/extern";
 export type { Item, ReadonlyItem } from "@/shared/ecs/extern";
 export {
   zItem,
@@ -74,6 +63,17 @@ import {
   defaultItem,
   serializeItem,
   deserializeItem,
+} from "@/shared/ecs/extern";
+import { ReadonlyBiomesId, BiomesId, zBiomesId } from "@/shared/ids";
+import {
+  defaultBiomesId,
+  serializeBiomesId,
+  deserializeBiomesId,
+} from "@/shared/ecs/extern";
+export {
+  defaultBiomesId,
+  serializeBiomesId,
+  deserializeBiomesId,
 } from "@/shared/ecs/extern";
 import { z } from "zod";
 import { isInteger } from "lodash";

--- a/src/shared/ecs/gen/types.ts
+++ b/src/shared/ecs/gen/types.ts
@@ -1,21 +1,6 @@
 // GENERATED: This file is generated from types.ts.j2. Do not modify directly.
-// Content Hash: aed777d4bcdfbe670f7a484dbc08b7db
+// Content Hash: 1def4e7a68650a8bceb0668ab3147bf2
 
-export type { Item, ReadonlyItem } from "@/shared/ecs/extern";
-export {
-  zItem,
-  defaultItem,
-  serializeItem,
-  deserializeItem,
-} from "@/shared/ecs/extern";
-import {
-  Item,
-  ReadonlyItem,
-  zItem,
-  defaultItem,
-  serializeItem,
-  deserializeItem,
-} from "@/shared/ecs/extern";
 export type { ItemAndCount, ReadonlyItemAndCount } from "@/shared/ecs/extern";
 export {
   zItemAndCount,
@@ -41,6 +26,21 @@ export {
   defaultBiomesId,
   serializeBiomesId,
   deserializeBiomesId,
+} from "@/shared/ecs/extern";
+export type { Item, ReadonlyItem } from "@/shared/ecs/extern";
+export {
+  zItem,
+  defaultItem,
+  serializeItem,
+  deserializeItem,
+} from "@/shared/ecs/extern";
+import {
+  Item,
+  ReadonlyItem,
+  zItem,
+  defaultItem,
+  serializeItem,
+  deserializeItem,
 } from "@/shared/ecs/extern";
 export type { ShardId, ReadonlyShardId } from "@/shared/ecs/extern";
 export {

--- a/src/shared/ids.ts
+++ b/src/shared/ids.ts
@@ -105,3 +105,6 @@ export const zLegacyIdOrBiomesId = z
   });
 
 export type LegacyIdOrBiomesId = z.infer<typeof zLegacyIdOrBiomesId>;
+
+export const zUsernameOrAnyId = z.union([zLegacyIdOrBiomesId, z.string()]);
+export type UsernameOrAnyId = z.infer<typeof zUsernameOrAnyId>;

--- a/src/shared/util/text.ts
+++ b/src/shared/util/text.ts
@@ -32,3 +32,13 @@ export function article(stuff: string) {
 export function capitalize<T extends string>(stuff: T) {
   return (stuff[0].toUpperCase() + stuff.slice(1)) as Capitalize<T>;
 }
+
+export function snakeCaseToUpperCamalCase(snakeCase: string): string {
+  const words = snakeCase.split("_");
+  return words.map((name) => capitalize(name)).join("");
+}
+
+export function snakeCaseToCamalCase(snakeCase: string): string {
+  const [first, ...rest] = snakeCase.split("_");
+  return first + rest.map((name) => capitalize(name)).join("");
+}


### PR DESCRIPTION
copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why
- Addresses: https://github.com/ill-inc/biomes-game/issues/48
- We frequently had to run entity migration scripts because there wasn't a way to update ECS data from within the admin view.
- ECS Editor is accessible at `/admin/ecs/<username or entity id>`.
- Can enter the ECS view from `/admin/user/<username or entity id>` by clicking `Edit game data (ECS)`
![image](https://github.com/ill-inc/biomes-game/assets/45083086/313ea5ab-3842-468d-91c1-c15cce6faffe)

- Supported operations:
   - ADD (add a the default value of a component to an entity)
   - DELETE (delete a component from an entity - cannot delete and entity's `id`)
   - UPDATE (update a `boolean`, `string`, or `number` field within an entity component)
   
[ECSEditor.webm](https://github.com/ill-inc/biomes-game/assets/45083086/e635a8f9-cc10-40f6-966b-c2c78eb3e5cb)

### How
- Introduced new route: `/api/admin/ecs/edit`.
- Introduced new events: `AdminECSDeleteComponentEvent`, `AdminECSAddComponentEvent`, `AdminECSUpdateComponentEvent`.

copilot:walkthrough
