### PR TITLE
Add auth check for AdminIceEvent

### DIFF
--- a/src/server/logic/events/handlers/admin.ts
+++ b/src/server/logic/events/handlers/admin.ts
@@ -29,9 +29,17 @@ export const adminIceEventHandler = makeEventHandler("adminIceEvent", {
   mergeKey: (event) => event.entity_id,
   involves: (event) => ({
     entity: q.id(event.entity_id).includeIced(),
+    player: q.player(event.id),
   }),
-  apply: ({ entity }) => {
-    entity.setIced();
+  apply: ({ entity, player }) => {
+    const roles = player.roles() ?? new Set();
+    if (roles.has("admin")) {
+      entity.setIced();
+    } else {
+      log.error(
+        `Player ${player.id} tried to ice entity ${entity.id} without the admin role`
+      );
+    }
   },
 });
 


### PR DESCRIPTION
copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why
- Non admin users were able to ice entities, which we don't want to allow.

### how

copilot:walkthrough
