### PR TITLE
Report missing assets on `./b data-snapshot run`

### DIFF
--- a/scripts/b/data_snapshot.py
+++ b/scripts/b/data_snapshot.py
@@ -366,7 +366,7 @@ def fetch_asset_versions():
 
     return [(name, asset_versions[name]) for name in asset_versions]
 
-# Verify that the assets references in asset_versions.json have been downloaded.
+# Verify that the assets referenced in asset_versions.json have been downloaded.
 # Returns True if there are missing assets.
 @data_snapshot.command()
 @click.option(


### PR DESCRIPTION
copilot:poem

### Public Changelog
- Pulling from `main` can cause fetched assets to become out of sync. This results in 404s when running from a snapshot.
- Here we simply check if all the assets that are pointed to by `asset_versions.json` have been downloaded locally, during `./b data-snapshot run`. 

You can also run the check manually:
```bash
./b data-snapshot check-for-missing-assets [OPTIONS]
```


### Why
<!-- author to complete -->

### how

copilot:walkthrough
