### PR TITLE
Increase max startup time for redis

### DIFF
--- a/scripts/b/data_snapshot.py
+++ b/scripts/b/data_snapshot.py
@@ -327,7 +327,7 @@ def redis_server_started():
     return ping.communicate()[0] == b"PONG\n"
 
 
-MAX_REDIS_STARTUP_TIME = 90
+MAX_REDIS_STARTUP_TIME = 120
 class RedisServer(object):
     def __init__(self):
         pass

--- a/scripts/b/data_snapshot.py
+++ b/scripts/b/data_snapshot.py
@@ -327,23 +327,29 @@ def redis_server_started():
     return ping.communicate()[0] == b"PONG\n"
 
 
+MAX_REDIS_STARTUP_TIME = 90
 class RedisServer(object):
     def __init__(self):
         pass
 
     def __enter__(self):
-        click.secho("Starting redis-server...")
+        click.secho("Starting redis-server...", fg=WARNING_COLOR)
         self.process = subprocess.Popen("redis-server")
         # Wait for server to start.
         start_time = time.time()
+        last_message_time = start_time
         while True:
             if redis_server_started():
                 break
             time.sleep(1)
-            if time.time() - start_time > 15:
+            now = time.time()
+            if now - last_message_time > 5:
+                last_message_time = now
+                click.secho("Starting redis-server...", fg=WARNING_COLOR)
+            if now - start_time > MAX_REDIS_STARTUP_TIME:
                 self.process.terminate()
                 raise RuntimeError("redis-server failed to start.")
-        click.secho("redis-server started...")
+        click.secho("redis-server started", fg=GOOD_COLOR)
 
         return self.process
 


### PR DESCRIPTION
copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why
- For some devices, redis takes longer than 15 seconds to start. This meant that, although everything was working, redis was "failing to start" with a time out. This relaxes the max startup time to 120 seconds.

### how

copilot:walkthrough
