### PR TITLE
Mock TwitchBot for local builds

### DIFF
--- a/src/server/shared/twitch/twitch.ts
+++ b/src/server/shared/twitch/twitch.ts
@@ -14,6 +14,12 @@ export interface TwitchBot {
   getChannel: (channel: string) => Promise<TwitchChannel | undefined>;
 }
 
+export class DisabledTwitchBot implements TwitchBot {
+  async getChannel(_channel: string): Promise<TwitchChannel | undefined> {
+    return undefined;
+  }
+}
+
 export class TwitchBotImpl implements TwitchBot {
   private accessToken: string | undefined;
   private expiresAt: number | undefined;
@@ -99,6 +105,9 @@ export class TwitchBotImpl implements TwitchBot {
 export async function registerTwitchBot<C>(
   _loader: RegistryLoader<C>
 ): Promise<TwitchBot> {
+  if (process.env.NOVE_ENV !== "production" && !process.env.ALLOW_DEV_TWITCH) {
+    return new DisabledTwitchBot();
+  }
   const bot = new TwitchBotImpl();
   await bot.login();
   return bot;


### PR DESCRIPTION
copilot:poem

### Public Changelog
<!-- aggregated and sent to Discord users -->

### Why
- Only production builds (and employees) have access to the TwitchAPI key. This causes local builds that don't have access to fail on startup. If a build does not have access, we now use a mock twitch bot.
- The environment variable `ALLOW_DEV_TWITCH` can be set to `1` to explicitly enable the production twitch bot.

### how

copilot:walkthrough
