### PR TITLE
Run trigger server for data snapshot

### DIFF
--- a/scripts/b/data_snapshot.py
+++ b/scripts/b/data_snapshot.py
@@ -342,7 +342,7 @@ def run(ctx, pip_install: bool):
         # Actually run a local Biomes server.
         ctx.invoke(
             b.run,
-            target=["web"],
+            target=["web", "trigger"],
             redis=True,
             storage="memory",
             assets="local",


### PR DESCRIPTION
## Summary

- includes the trigger server in `./b data-snapshot run`
- fixes local snapshot sessions where players spawn but quests never unlock or advance

## Root Cause

`data-snapshot run` previously launched only the `web` target. That starts web, sync, sidefx, bikkie, and oob, but it does not start the trigger server. Quest state is computed by the trigger server, so a new dev player could have empty `challenges` state even though the Bikkie quest data and Jackie entity were present.

## Validation

- started the missing local `trigger` service against the running snapshot stack
- confirmed dev user `1701382829160394` moved from empty challenge state to `The Road Ahead` in progress
- `python -m py_compile scripts/b/data_snapshot.py`
